### PR TITLE
Add batch file to bypass PowerShell execution policy

### DIFF
--- a/launch_update_patchwork.cmd
+++ b/launch_update_patchwork.cmd
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -File .\update_patchwork.ps1


### PR DESCRIPTION
By default, .ps1 files cannot be executed directly without changing a system-wide security policy setting.

Happily this can be bypassed by running powershell with:

    -ExecutionPolicy Bypass