### PR TITLE
Don't ignore addons except Patchwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/addons/
+/addons/patchwork/
 /godot_editor/
 .patchwork_version


### PR DESCRIPTION
Currently Moddable Platformer doesn't use any other addons, but that might change. And a team modifying the project might want to add addons, which should be synced by Patchwork.

Only ignore the patchwork addon itself.