### PR TITLE
launcher: Await user input on error

### DIFF
--- a/launch-patchwork/src/main.rs
+++ b/launch-patchwork/src/main.rs
@@ -1,23 +1,35 @@
 use std::io;
 use std::process::Command;
 
+fn await_confirmation() -> () {
+    println!("Press Enter to continue...");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
+}
+
 fn main() -> io::Result<()> {
     // TODO: make this cross-platform
     let godot = std::env::current_dir()?.join("./godot_editor/godot.windows.editor.x86_64.exe");
 
     println!("Launching Godot from {:?}...", godot);
 
-    let status = Command::new(godot)
+    match Command::new(godot)
         .arg("-e")
         .arg("--path")
         .arg(".")
-        .status()?;
-
-    if status.success() {
-        println!("Godot editor launched successfully.");
-    } else {
-        println!("Godot editor exited with: {}", status);
-    }
+        .status() {
+            Ok(status) if status.success() => {
+                println!("Godot editor launched successfully.");
+            }
+            Ok(status) => {
+                println!("Godot editor exited with: {}", status);
+                await_confirmation();
+            }
+            Err(e) => {
+                println!("Failed to launch Godot: {}", e);
+                await_confirmation();
+            }
+        }
 
     Ok(())
 }


### PR DESCRIPTION
Previously, if the Godot editor failed to launch (perhaps because it has not been downloaded!), the terminal window would disappear too quickly for the error message to be legible.

Add the same "Press Enter to continue..." prompt as in the updater, but only in
the error case. Handle two error paths:

- The process could not be spawned
- The process was spawned but exited with a non-zero status
