### PR TITLE
linux: Support xdg-terminal-exec (and ptyxis)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,10 @@ fn relaunch_in_terminal() -> Result<(), ()> {
 
     // Try common terminal emulators
     let terminals = [
+        ("xdg-terminal-exec", &["--"]),
         ("x-terminal-emulator", &["-e"]),
         ("gnome-terminal", &["--"]),
+        ("ptyxis", &["--"]),
         ("konsole", &["-e"]),
         ("xterm", &["-e"]),
         ("alacritty", &["-e"]),


### PR DESCRIPTION
Present-day Fedora (or at least Bluefin 43) does not ship with any of the terminal emulators currently supported.

Add support for ptyxis, the specific terminal emulator it does ship with.

Also support xdg-terminal-exec which launches the best-available terminal emulator.