### PR TITLE
ci: Build linux binary against musl, not glibc

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -18,16 +18,23 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl-tools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y musl-tools
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --target x86_64-unknown-linux-musl
 
       - name: Collect executables
         shell: bash
         run: |
           ls -l target/release
           mkdir -p artifacts
-          cp target/release/backstitch-launcher artifacts/backstitch-launcher-linux
+          cp target/x86_64-unknown-linux-musl/release/backstitch-launcher artifacts/backstitch-launcher-linux
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
This should improve compatibility with older Linux distributions.

Fixes https://github.com/inkandswitch/backstitch-launcher/issues/19
