### PR TITLE
Add dotnet detection capabities and initial paths for dotnet builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,22 @@ fn relaunch_in_terminal_linux() -> Result<(), ()> {
     return Err(())
 }
 
+fn fail() {
+    println!("Press Enter to continue...");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
+    // Temporary fix before moving to using main releases rather than custom packaging.
+    // Or we'd need to package .net versions as well...
+    if update::is_dotnet() {
+        println!("Found Dotnet project files. Dotnet builds are not yet supported.");
+        fail();
+        return ExitCode::FAILURE;
+    }
+
     // Hacky fix to ensure we always launch a terminal for Godot. 
     // Queries a bunch of common terminal emulators...
     // If someone doesn't have any of these available... hopefully they know how to run it from the terminal.
@@ -132,9 +146,7 @@ async fn main() -> ExitCode {
     let res = download_and_launch().await;
     // pause in case of error, so we can read it
     if let Err(_) = res {
-        println!("Press Enter to continue...");
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input).unwrap();
+        fail();
         return ExitCode::FAILURE;
     }
     return ExitCode::SUCCESS;

--- a/src/update.rs
+++ b/src/update.rs
@@ -16,6 +16,7 @@ const VERSION_FILE: &str = ".backstitch_version";
 const GODOT_OUTPUT_DIR: &str = "./godot_editor";
 const PLUGIN_ARTIFACT_PREFIX: &str = "backstitch";
 const PLUGIN_OUTPUT_DIR: &str = "./addons/backstitch";
+const CS_EXTS: [&str; 2] = ["csproj", "sln"];
 
 #[derive(Debug, Deserialize)]
 struct Release {
@@ -111,16 +112,47 @@ pub async fn get_current_version() -> Option<String> {
     };
 }
 
+pub fn is_dotnet() -> bool {
+    // Iterate root files
+    let entries = std::fs::read_dir(".").unwrap();
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if CS_EXTS.contains(&ext.to_str().unwrap_or_default()) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
 pub fn get_godot_path() -> PathBuf {
-    let exe_name = if cfg!(target_os = "windows") {
-        "godot.windows.editor.x86_64.exe"
-    } else if cfg!(target_os = "linux") {
-        "godot.linuxbsd.editor.x86_64"
-    } else if cfg!(target_os = "macos") {
-        // Godot macOS builds are inside an .app bundle
-        "godot_macos_editor.app/Contents/MacOS/Godot"
+    let exe_name = if is_dotnet() {
+        // Assuming we're inside the archive
+        if cfg!(target_os = "windows") {
+            "Godot_v4.7-stable_mono_win64.exe"
+        } else if cfg!(target_os = "linux") {
+            "Godot_v4.7-stable_mono_linux.x86_64"
+        } else if cfg!(target_os = "macos") {
+            // Godot macOS builds are inside an .app bundle
+            "Godot_mono.app/Contents/MacOS/Godot"
+        } else {
+            panic!("Unsupported OS");
+        }
     } else {
-        panic!("Unsupported OS");
+        if cfg!(target_os = "windows") {
+            "godot.windows.editor.x86_64.exe"
+        } else if cfg!(target_os = "linux") {
+            "godot.linuxbsd.editor.x86_64"
+        } else if cfg!(target_os = "macos") {
+            // Godot macOS builds are inside an .app bundle
+            "godot_macos_editor.app/Contents/MacOS/Godot"
+        } else {
+            panic!("Unsupported OS");
+        }
     };
 
     return std::env::current_dir()


### PR DESCRIPTION
Partially covers #24 
Here are file paths for future reference in regards to the structure of dotnet releases from Godot
```bash
frida@cofftop:~/Downloads/godot$ tree -L 2
.
├── Godot_v4.7-stable_mono_linux_x86_64
│   ├── GodotSharp
│   └── Godot_v4.7-stable_mono_linux.x86_64
├── Godot_v4.7-stable_mono_linux_x86_64.zip
├── Godot_v4.7-stable_mono_macos.universal
│   └── Godot_mono.app
├── Godot_v4.7-stable_mono_macos.universal.zip
├── Godot_v4.7-stable_mono_win64
│   ├── GodotSharp
│   ├── Godot_v4.7-stable_mono_win64_console.exe
│   └── Godot_v4.7-stable_mono_win64.exe
└── Godot_v4.7-stable_mono_win64.zip

7 directories, 6 files
```