### PR TITLE
Add .gdignore to godot_editor/ and macOS .app bundle

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -48,6 +48,7 @@ jobs:
           cp -f target/universal/release/backstitch-launcher \
             "$BUNDLE_APP/Contents/MacOS/backstitch-launcher"
           chmod +x "$BUNDLE_APP/Contents/MacOS/backstitch-launcher"
+          touch "$BUNDLE_APP/.gdignore"
           mkdir -p artifacts
           rm -rf artifacts/backstitch-launcher-macos.app
           cp -R "$BUNDLE_APP" artifacts/backstitch-launcher-macos.app

--- a/src/godot_update.rs
+++ b/src/godot_update.rs
@@ -59,6 +59,9 @@ pub async fn try_update(
     #[cfg(not(target_os = "windows"))]
     utils::make_folder_contents_executable(godot_dir).await?;
 
+    let gdignore_path = godot_dir.join(".gdignore");
+    let _ = tokio::fs::File::create(&gdignore_path).await?;
+
     // We do no validation to ensure that Godot is actually downloaded to the expected path.
     Ok(exe_path)
 }


### PR DESCRIPTION
This avoids Godot trying to feast on the files within.

Resolves https://github.com/inkandswitch/backstitch-launcher/issues/15
Resolves https://github.com/inkandswitch/backstitch/issues/212