### PR TITLE
ci: Correctly skip macOS and Windows signing on PRs from forks

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Mac Sign
         # Only run this if it's not a PR or the PR is from the main repository
-        if: github.event_name != 'pull_request' || github.repository == 'inkandswitch/backstitch-launcher'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/macos-sign
         with:
           FRAMEWORK_PATH: ${{ github.workspace }}/artifacts/backstitch-launcher-macos.app

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Windows Sign
         # Only run this if it's not a PR or the PR is from the main repository
-        if: github.event_name != 'pull_request' || github.repository == 'inkandswitch/backstitch-launcher'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/windows-sign
         with:
           BINARY_PATHS: |
@@ -35,7 +35,7 @@ jobs:
           KMS_LOCATION: ${{ secrets.KMS_LOCATION }}
           KMS_KEYRING: ${{ secrets.KMS_KEYRING }}
           KMS_KEY: ${{ secrets.KMS_KEY }}
-            
+
       - name: Collect executables
         shell: bash
         run: |


### PR DESCRIPTION
`github.repository` is always the repository where the workflow is running, so previously this condition does nothing and PRs from forks still try and fail to sign the Windows and macOS builds.

The check we want is "is the PR head repo the same as the upstream repo?". I believe this is the most concise way to write that.