### PR TITLE
Add CWD options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ dotnet="<auto|true|false>" # Whether to use the .NET build of Godot. If set to a
 allow_prerelease=<true|false> # Whether to allow downloading pre-release versions of Backstitch.
 godot_path="<GODOT_PATH>" # Skip the Godot download and open the exe from a path instead. 
 godot_url="<GODOT_URL>" # Specify a custom Godot URL to download from. Cross-platform support doesn't work, so it had better match your mono and platform versions!
+cwd="<PATH>" # Use a custom CWD for the Backstitch Launcher.
 ```
 
 Command-line specified arguments will take precedence over the `[backstitch_launcher]` section.

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,10 @@ pub struct CommandConfig {
     #[arg(long)]
     pub godot_path: Option<PathBuf>,
 
+    #[clap(help = "Use a custom working directory. Defaults to the current directory.")]
+    #[arg(long)]
+    pub cwd: Option<PathBuf>,
+
     #[clap(
         help = "Whether to download the latest prerelease version of Backstitch, instead of the stable version. Warning: Here be dragons!"
     )]
@@ -104,6 +108,12 @@ pub async fn setup_config() -> Result<CommandConfig, ConfigError> {
             && command_config.godot_path.is_none()
         {
             command_config.godot_path = Some(godot_path);
+        }
+
+        if let Some(cwd) = file_config.cwd
+            && command_config.cwd.is_none()
+        {
+            command_config.cwd = Some(cwd);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,14 @@ async fn main() -> ExitCode {
         cwd = project_root.to_path_buf();
     };
 
+    // Change the current working directory to the custom override
+    if let Some(custom_cwd) = &config.cwd {
+        let custom_cwd = std::fs::canonicalize(custom_cwd).expect("Failed to canonicalize path");
+        std::env::set_current_dir(&custom_cwd).expect("Failed to set current working directory");
+        println!("Changed CWD from {:?} to {:?}", cwd, custom_cwd);
+        cwd = custom_cwd;
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
         use std::io::IsTerminal;


### PR DESCRIPTION
Resolves #28 
Uses canonicalize which makes it allow for stuff like `./backstitch-launcher --cwd ../../test`